### PR TITLE
fix(sec): upgrade tk.mybatis:mapper to 4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>tk.mybatis</groupId>
             <artifactId>mapper</artifactId>
-            <version>3.4.2</version>
+            <version>4.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.pagehelper</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tk.mybatis:mapper 3.4.2
- [MPS-2022-51955](https://www.oscs1024.com/hd/MPS-2022-51955)


### What did I do？
Upgrade tk.mybatis:mapper from 3.4.2 to 4.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS